### PR TITLE
fix: update celery

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,6 +12,6 @@ gunicorn
 kubernetes~=26.1.0
 python-dotenv~=0.21.0
 PyYAML~=6.0
-celery==5.2.7
+celery==5.5.3
 redis==4.5.5
 ruamel.yaml===0.17.32


### PR DESCRIPTION
Update celery as difference in versioning before SC4SNMP and SC4SNMP-UI caused this issue:

```
[2025-10-23 06:38:46,571: INFO/MainProcess] celery@ui-backend-worker-deployment-bb6d46d6d-dzqvg ready.
[2025-10-23 06:38:55,413: INFO/MainProcess] sync with celery@snmp2-splunk-connect-for-snmp-worker-poller-648b6f669-w8lv4
[2025-10-23 06:38:55,424: ERROR/MainProcess] Control command error: ValueError('not enough values to unpack (expected 3, got 1)')
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/celery/worker/pidbox.py", line 44, in on_message
    self.node.handle_message(body, message)
  File "/usr/local/lib/python3.9/site-packages/kombu/pidbox.py", line 143, in handle_message
    return self.dispatch(**body)
  File "/usr/local/lib/python3.9/site-packages/kombu/pidbox.py", line 110, in dispatch
    self.reply({self.hostname: reply},
  File "/usr/local/lib/python3.9/site-packages/kombu/pidbox.py", line 147, in reply
    self.mailbox._publish_reply(data, exchange, routing_key, ticket,
  File "/usr/local/lib/python3.9/site-packages/kombu/pidbox.py", line 277, in _publish_reply
    producer.publish(
  File "/usr/local/lib/python3.9/site-packages/kombu/messaging.py", line 190, in publish
    return _publish(
  File "/usr/local/lib/python3.9/site-packages/kombu/connection.py", line 556, in _ensured
    return fun(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/kombu/messaging.py", line 214, in _publish
    return channel.basic_publish(
  File "/usr/local/lib/python3.9/site-packages/kombu/transport/virtual/base.py", line 610, in basic_publish
    return self.typeof(exchange).deliver(
  File "/usr/local/lib/python3.9/site-packages/kombu/transport/virtual/exchange.py", line 74, in deliver
    for queue in _lookup(exchange, routing_key):
  File "/usr/local/lib/python3.9/site-packages/kombu/transport/virtual/base.py", line 721, in _lookup
    R = self.typeof(exchange).lookup(
  File "/usr/local/lib/python3.9/site-packages/kombu/transport/virtual/exchange.py", line 66, in lookup
    return {
  File "/usr/local/lib/python3.9/site-packages/kombu/transport/virtual/exchange.py", line 67, in <setcomp>
    queue for rkey, _, queue in table
ValueError: not enough values to unpack (expected 3, got 1)
```