### PR TITLE
ci: migrate GH_TOKEN_ADMIN to GitHub App token in release workflow

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -138,6 +138,13 @@ jobs:
         with:
           submodules: false
           persist-credentials: false
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - uses: actions/setup-node@v4.0.2
         with:
           node-version: "20.12"
@@ -152,5 +159,5 @@ jobs:
           extra_plugins: |
             semantic-release-replace-plugin@1.2.7
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_ADMIN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
## Summary

- Replace `GH_TOKEN_ADMIN` (long-lived PAT) with a short-lived GitHub App installation token via `actions/create-github-app-token@v3` in the `release` job of `ci-release.yaml`
- The new token is scoped to the repository owner's org and expires after 1 hour, improving security posture
- `GH_APP_CLIENT_ID` and `GH_APP_PRIVATE_KEY` secrets are already available via centralized secret sync


Made with [Cursor](https://cursor.com)